### PR TITLE
Remove Twitter from list of social sign-in options

### DIFF
--- a/views/login.ejs
+++ b/views/login.ejs
@@ -24,7 +24,6 @@
             <li><a href="/login/discord" class="button discord">Discord</a></li>
             <li><a href="/login/google" class="button google">Google</a></li>
             <li><a href="/login/facebook" class="button facebook">Facebook</a></li>
-            <li><a href="/login/twitter" class="button twitter">Twitter</a></li>
           </ul>
         </div>
       </section>


### PR DESCRIPTION
Twitter doesn't yet support OAuth 2.0 authentication like the other options here do. Or at least, it's not supported through Passport. That leaves us with the old OAuth 1.0 strategy, but that requires a session. We've gotten this far with a perfectly session-less server that only connects to our database through the API, and I'm not really willing to compromise that just to make it possible to log in with Twitter.

We're keeping the CSS styles, so if we ever get a working Twitter OAuth 2.0 strategy for Passport.js, we can add it in pretty easily. But until that happens, we won't have a Twitter login.